### PR TITLE
Fixbuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+dist
 node_modules
 yarn-error.log

--- a/index.html
+++ b/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <x-index-page></x-index-page>
-    <script type="module" src="src/pages/IndexPage.ts"></script>
+    <script type="module" src="/src/pages/IndexPage.ts"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite dev",
     "start": "vite --host",
     "build": "vite build",
+    "preview": "vite preview",
     "lint": "eslint src --fix"
   },
   "devDependencies": {

--- a/src/components/HelloWorld.ts
+++ b/src/components/HelloWorld.ts
@@ -7,6 +7,51 @@ import { TW } from "../util/TailwindMixin";
 @customElement("x-hello-world")
 export class HelloWorld extends TW(LitElement) {
   render(): TemplateResult {
-    return html` <h1 class="text-2xl">Hello world!</h1> `;
+    return html`
+      <div class="divide-y divide-gray-300/50">
+        <div class="py-8 text-base leading-7 space-y-6 text-gray-600">
+          <p>An advanced online playground for Tailwind CSS, including support for things like:</p>
+          <ul class="space-y-4">
+            <li class="flex items-center">
+              <svg class="w-6 h-6 flex-none fill-sky-100 stroke-sky-500 stroke-2" stroke-linecap="round"
+                stroke-linejoin="round">
+                <circle cx="12" cy="12" r="11" />
+                <path d="m8 13 2.165 2.165a1 1 0 0 0 1.521-.126L16 9" fill="none" />
+              </svg>
+              <p class="ml-4">
+                Customizing your
+                <code class="text-sm font-bold text-gray-900">tailwind.config.js</code> file
+              </p>
+            </li>
+            <li class="flex items-center">
+              <svg class="w-6 h-6 flex-none fill-sky-100 stroke-sky-500 stroke-2" stroke-linecap="round"
+                stroke-linejoin="round">
+                <circle cx="12" cy="12" r="11" />
+                <path d="m8 13 2.165 2.165a1 1 0 0 0 1.521-.126L16 9" fill="none" />
+              </svg>
+              <p class="ml-4">
+                Extracting classes with
+                <code class="text-sm font-bold text-gray-900">@apply</code>
+              </p>
+            </li>
+            <li class="flex items-center">
+              <svg class="w-6 h-6 flex-none fill-sky-100 stroke-sky-500 stroke-2" stroke-linecap="round"
+                stroke-linejoin="round">
+                <circle cx="12" cy="12" r="11" />
+                <path d="m8 13 2.165 2.165a1 1 0 0 0 1.521-.126L16 9" fill="none" />
+              </svg>
+              <p class="ml-4">Code completion with instant preview</p>
+            </li>
+          </ul>
+          <p>Perfect for learning how the framework works, prototyping a new idea, or creating a demo to share online.</p>
+        </div>
+        <div class="pt-8 text-base leading-7 font-semibold">
+          <p class="text-gray-900">Want to dig deeper into Tailwind?</p>
+          <p>
+            <a href="https://tailwindcss.com/docs" class="text-sky-500 hover:text-sky-600">Read the docs &rarr;</a>
+          </p>
+        </div>
+      </div>
+    `;
   }
 }

--- a/src/util/TailwindMixin.ts
+++ b/src/util/TailwindMixin.ts
@@ -1,13 +1,13 @@
+import styles from '../styles/main.css';
+
 export const TW = <T extends LitMixin>(superClass: T): T =>
   class extends superClass {
     connectedCallback() {
       super.connectedCallback();
-
-      const link = document.createElement("link");
-      link.rel = "stylesheet";
-      link.type = "text/css";
-      link.href = new URL("../styles/main.css", import.meta.url).href;
-
-      this.shadowRoot.append(link);
+      const mainCSS = document.createElement('style');
+      mainCSS.appendChild(document.createTextNode(styles));
+      if (this.shadowRoot) {
+        this.shadowRoot.append(mainCSS);
+      }
     }
   };


### PR DESCRIPTION
Hi, thanks for your great Lit-Tailwind integration solution!

I found that it won't apply Tailwind styles in built web app. That's because Vite doesn't help compile `../styles/main.css` when building. Thus, only the base64 encoded `@import url(./tailwind.css);@import url(./global.css);` stays in the `<head>`, which is definitely not working.

According to this [doc](https://vitejs.dev/guide/features.html#postcss), I found that the only way to build this css file is to import it as a module. In this way, the compiled css can be appended in <head>.