### PR TITLE
Hotfix: Tailwind is not included in production builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 yarn-error.log
+dist

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="./src/styles/main.css" />
     <title>Document</title>
   </head>
   <body>

--- a/src/pages/IndexPage.ts
+++ b/src/pages/IndexPage.ts
@@ -4,7 +4,6 @@ import { html, LitElement } from "lit";
 import { customElement } from "lit/decorators.js";
 
 import "../components/HelloWorld";
-import "../styles/main.css";
 import { TW } from "../util/TailwindMixin";
 
 @customElement("x-index-page")

--- a/src/util/TailwindMixin.ts
+++ b/src/util/TailwindMixin.ts
@@ -3,11 +3,8 @@ export const TW = <T extends LitMixin>(superClass: T): T =>
     connectedCallback() {
       super.connectedCallback();
 
-      const link = document.createElement("link");
-      link.rel = "stylesheet";
-      link.type = "text/css";
-      link.href = new URL("../styles/main.css", import.meta.url).href;
-
-      this.shadowRoot.append(link);
+      document.head.querySelectorAll("link[rel='stylesheet']").forEach((link) => {
+        this.shadowRoot.append(link.cloneNode());
+      });
     }
   };

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,3 @@
 import { defineConfig } from 'vite';
 
-defineConfig({
-});
+export default defineConfig({});


### PR DESCRIPTION
Until importing preprocessed CSS documents as URLs is supported in Vite (see https://github.com/vitejs/vite/pull/5796) it is not possible for us to directly define which documents should be loaded into web components. An alternative is to load a CSS document directly into the head and simply clone it into each web component.

Fixes #2, also probably acts as a better solution than #1.